### PR TITLE
Spring MVC 예외 처리 간편화 (ResponseEntityExceptionHandler 상속)

### DIFF
--- a/src/main/java/com/project/studylink/dto/response/ErrorResponse.java
+++ b/src/main/java/com/project/studylink/dto/response/ErrorResponse.java
@@ -15,6 +15,11 @@ public class ErrorResponse {
     @JsonInclude(JsonInclude.Include.NON_NULL)
     private Map<String, String> fields;
 
+    public ErrorResponse(String code, String message) {
+        this.code = code;
+        this.message = message;
+    }
+
     public ErrorResponse(ErrorCode errorCode) {
         this.code = errorCode.name();
         this.message = errorCode.getMessage();

--- a/src/main/java/com/project/studylink/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/project/studylink/exception/GlobalExceptionHandler.java
@@ -4,13 +4,17 @@ import com.project.studylink.dto.response.ApiResponse;
 import com.project.studylink.dto.response.ErrorResponse;
 import com.project.studylink.enums.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.lang.Nullable;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
@@ -21,59 +25,58 @@ import static com.project.studylink.enums.ErrorCode.*;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler{
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
-    public ResponseEntity<?> handleCustomException(BusinessException ex) {
+    public ResponseEntity<Object> handleCustomException(BusinessException ex) {
         log.warn("handleBusinessException : {} -> ErrorCode : {}", ex.toString(), ex.getErrorCode().name());
         return handleExceptionInternal(ex.getErrorCode());
     }
 
-    @ExceptionHandler(MethodArgumentNotValidException.class)
-    public ResponseEntity<?> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
-        log.warn("handleMethodArgumentNotValidException : {}", ex.toString());
-        return handleExceptionInternal(ex.getFieldErrors());
-    }
-
-    @ExceptionHandler(NoResourceFoundException.class)
-    public ResponseEntity<?> handleNoResourceFoundException(NoResourceFoundException ex) {
-        log.warn("handleNoResourceFoundException : {}", ex.toString());
-        return handleExceptionInternal(NOT_FOUND_RESOURCE);
-    }
-
     @ExceptionHandler(BadCredentialsException.class)
-    public ResponseEntity<?> handleBadCredentialsException(BadCredentialsException ex) {
+    public ResponseEntity<Object> handleBadCredentialsException(BadCredentialsException ex) {
         log.warn("handleBadCredentialsException : {}", ex.toString());
         return handleExceptionInternal(LOGIN_FAIL);
-    }
-
-    @ExceptionHandler(HttpMessageNotReadableException.class)
-    public ResponseEntity<?> handleHttpMessageNotReadableException(HttpMessageNotReadableException ex) {
-        log.warn("handleHttpMessageNotReadableException : {}", ex.toString());
-        return handleExceptionInternal(HTTP_MESSAGE_NOT_READABLE);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleUnexpectedException(Exception ex) {
         log.warn("handleUnexpectedException : {}", ex.toString());
+        log.warn("handleUnexpectedException : {}", ex.getStackTrace());
         return handleExceptionInternal(INTERNAL_SERVER_ERROR);
     }
 
-    private ResponseEntity<?> handleExceptionInternal(ErrorCode errorCode) {
-        ErrorResponse error = new ErrorResponse(errorCode);
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("handleMethodArgumentNotValid : {}", ex.toString());
+        return handleExceptionInternal(ex.getFieldErrors());
+    }
 
+    @Override
+    protected ResponseEntity<Object> handleNoResourceFoundException(NoResourceFoundException ex, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        log.warn("handleNoResourceFoundException : {}", ex.toString());
+        return handleExceptionInternal(NOT_FOUND_RESOURCE);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        ErrorResponse error = new ErrorResponse("REQUEST_ERROR", ex.getMessage());
+        return ResponseEntity.status(statusCode)
+                .body(ApiResponse.error(error));
+    }
+    private ResponseEntity<Object> handleExceptionInternal(ErrorCode errorCode) {
+        ErrorResponse error = new ErrorResponse(errorCode);
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ApiResponse.error(error));
     }
 
-    private ResponseEntity<?> handleExceptionInternal(List<FieldError> fieldErrors) {
+    private ResponseEntity<Object> handleExceptionInternal(List<FieldError> fieldErrors) {
         Map<String, String> fields = new HashMap<>();
 
         fieldErrors.forEach(fieldError -> fields
                 .put(fieldError.getField(), fieldError.getDefaultMessage()));
 
         ErrorResponse error = new ErrorResponse(FIELD_ERROR, fields);
-
         return ResponseEntity.status(FIELD_ERROR.getHttpStatus())
                 .body(ApiResponse.error(error));
     }


### PR DESCRIPTION
GlobalExceptionHandler에 ResponseEntityExceptionHandler를 상속하여 Spring MVC 예외를 모두 처리 하지 않아도 됨.
ResponseEntityExceptionHandler를 상속하지 않으면 모든 Spring MVC 예외에 대하여  @ExceptionHandler 메서드를 만들어 주어야함.